### PR TITLE
Ensure onToggle is called when on is controlled but setOnState is called

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -159,6 +159,7 @@ test('onToggle gets called in controlled prop scenario', () => {
   expect(spy).not.toHaveBeenCalled()
   wrapper.setProps({on: true})
   expect(spy).toHaveBeenCalled()
+  expect(spy.mock.calls.length).toBe(1)
 })
 
 test('onToggle gets called with fresh state in controlled prop scenario', () => {
@@ -166,6 +167,17 @@ test('onToggle gets called with fresh state in controlled prop scenario', () => 
   const {wrapper} = setup({on: false, onToggle: spy})
   wrapper.setProps({on: true})
   expect(spy).toHaveBeenLastCalledWith(true, expect.anything())
+  expect(spy.mock.calls.length).toBe(1)
+})
+
+test('onToggle gets called when setOnState is called in controlled prop scenario', () => {
+  const spy = jest.fn()
+  const {getTogglerProps} = setup({on: false, onToggle: spy})
+  const {onClick} = getTogglerProps()
+  const fakeEvent = {target: null}
+  onClick(fakeEvent)
+  expect(spy).toHaveBeenLastCalledWith(true, expect.anything())
+  expect(spy.mock.calls.length).toBe(1)
 })
 
 function setup({children = () => <div />, ...props} = {}) {

--- a/src/index.js
+++ b/src/index.js
@@ -69,6 +69,9 @@ class Toggle extends Component {
   }
 
   setOnState = (state = !this.getOn()) => {
+    if (this.getOn() !== state) {
+      this.props.onToggle(state, this.getTogglerStateAndHelpers())
+    }
     this.setState({on: state})
   }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

<!-- Why are these changes necessary? -->
**Why**:

<!-- How were these changes implemented? -->
**How**:

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
